### PR TITLE
Add dummy bootstrap node to hide errors

### DIFF
--- a/start-node.sh
+++ b/start-node.sh
@@ -11,6 +11,8 @@ if [ ! -e "$IPFS_PATH/config" ]; then
   ipfs init
   cp /data/swarm.key "$IPFS_PATH"
   ipfs bootstrap rm all >/dev/null
+  # Dummy boostrap node to prevent error messages
+  ipfs bootstrap add /ip4/127.0.0.1/tcp/1/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ
   ipfs config Addresses.API "/ip4/0.0.0.0/tcp/500${node_id}"
   ipfs config Addresses.Gateway "/ip4/0.0.0.0/tcp/808${node_id}"
   ipfs config Addresses.Swarm --json "[\"/ip4/127.0.0.1/tcp/400${node_id}\"]"


### PR DESCRIPTION
If no bootstrap node is provided the nodes will repeatedly log an error message about that. Having a dummy bootstrap node that is not reachable prevents logging these errors.