### PR TITLE
Setup CircleCI and push on master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,23 @@
+version: '2'
+jobs:
+  build:
+    docker:
+    - image: docker:18.09.1
+    environment:
+      IMAGE_NAME: gcr.io/opensourcecoin/ipfs-test-network
+    steps:
+    - setup_remote_docker
+    - checkout
+    - run:
+        name: Build image
+        command: |
+          docker build . --tag "$IMAGE_NAME"
+    - run:
+        name: Push image
+        command: |
+          if [[ "$CIRCLE_BRANCH" = "master" ]]; then
+            # This key belongs to circleci-image-uploader@opensourcecoin.iam.gserviceaccount.com
+            # The key ID is e7dd392d78a676d0d5bbe19ad5046aa2b9d91939
+            docker login -u _json_key -p "$(echo $GCLOUD_SERVICE_KEY | base64 -d)" https://gcr.io
+            docker push "$IMAGE_NAME"
+          fi

--- a/README.md
+++ b/README.md
@@ -13,13 +13,12 @@ Usage
 -----
 
 ```
-docker build . -t ipfs-test-network
 docker run \
   --volume ipfs-test-data:/data \
   --publish 4001:4001 \
   --publish 5001:5001 \
   --name ipfs-test-network
-  ipfs-test-network
+  gcr.io/opensourcecoin/ipfs-test-network
 ```
 
 You can now talk to a node in the test network from your host machine through


### PR DESCRIPTION
We build the image with CircleCI and push it to `gcr.io` on master
builds.