### PR TITLE
Revert to go-ipfs v0.4.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ipfs/go-ipfs:v0.4.19
+FROM ipfs/go-ipfs:v0.4.18
 
 # Running as non-root user has some issues. Future go-ipfs images will
 # be running as root again. See https://github.com/ipfs/go-ipfs/pull/6040

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ IPFS Test Network Container
 
 Run an isolated, private IPFS network in a Docker container.
 
-The container runs two IPFS nodes that share a [private IPFS
-network][ipfs-private-network]. This allows for isolation from the main IPFS
-network and fast and reliable responses, especially with IPNS.
+The container runs two IPFS nodes using [go-ipfs v0.4.18][go-ipfs-image] that
+share a [private IPFS network][ipfs-private-network]. This allows for isolation
+from the main IPFS network and fast and reliable responses, especially with
+IPNS.
 
+[go-ipfs-image]: https://hub.docker.com/r/ipfs/go-ipfs/
 [ipfs-private-network]: https://github.com/ipfs/go-ipfs/blob/master/docs/experimental-features.md#private-networks
 
 Usage


### PR DESCRIPTION
We saw some issues with go-ipfs v0.4.19 in the Radicle project. We’ll revert to v0.4.18 for now.